### PR TITLE
Refactor/use ids for current minmounts

### DIFF
--- a/EorzeanInfo/app/src/main/java/chesire/eorzeaninfo/views/CharacterDetailsActivity.java
+++ b/EorzeanInfo/app/src/main/java/chesire/eorzeaninfo/views/CharacterDetailsActivity.java
@@ -114,14 +114,14 @@ public class CharacterDetailsActivity extends AppCompatActivity implements Navig
             case R.id.character_details_mounts:
                 getSupportFragmentManager()
                         .beginTransaction()
-                        .replace(R.id.character_profile_container, MinMountFragment.newInstance(mCharacter.getMounts(), mMinMountRepository.getAllMounts()))
+                        .replace(R.id.character_profile_container, MinMountFragment.newInstance(mCharacter.getData().getMounts(), mMinMountRepository.getAllMounts()))
                         .commit();
                 break;
 
             case R.id.character_details_minions:
                 getSupportFragmentManager()
                         .beginTransaction()
-                        .replace(R.id.character_profile_container, MinMountFragment.newInstance(mCharacter.getMinions(), mMinMountRepository.getAllMinions()))
+                        .replace(R.id.character_profile_container, MinMountFragment.newInstance(mCharacter.getData().getMinions(), mMinMountRepository.getAllMinions()))
                         .commit();
                 break;
 

--- a/EorzeanInfo/parsing_library/src/main/java/chesire/eorzeaninfo/parsing_library/models/CharacterDataModel.java
+++ b/EorzeanInfo/parsing_library/src/main/java/chesire/eorzeaninfo/parsing_library/models/CharacterDataModel.java
@@ -22,8 +22,8 @@ public class CharacterDataModel implements Parcelable {
     //private City
     //private Grand company
     private List<ClassModel> classjobs;
-    private List<MinMountModel> mounts;
-    private List<MinMountModel> minions;
+    private List<Integer> mounts;
+    private List<Integer> minions;
 
     /**
      * Gets the model for the character class represented by cClass
@@ -46,18 +46,18 @@ public class CharacterDataModel implements Parcelable {
     /**
      * Gets a list of all acquired mounts
      *
-     * @return List of mounts that have been acquired
+     * @return List of mount ids that have been acquired
      */
-    public List<MinMountModel> getMounts() {
+    public List<Integer> getMounts() {
         return mounts;
     }
 
     /**
      * Gets a list of all acquired minions
      *
-     * @return List of minions that have been acquired
+     * @return List of minion ids that have been acquired
      */
-    public List<MinMountModel> getMinions() {
+    public List<Integer> getMinions() {
         return minions;
     }
 
@@ -72,8 +72,8 @@ public class CharacterDataModel implements Parcelable {
         gender = in.readString();
         nameday = in.readString();
         in.readList(classjobs, ClassModel.class.getClassLoader());
-        in.readList(mounts, MinMountModel.class.getClassLoader());
-        in.readList(minions, MinMountModel.class.getClassLoader());
+        in.readList(mounts, Integer.class.getClassLoader());
+        in.readList(minions, Integer.class.getClassLoader());
     }
 
     /**

--- a/EorzeanInfo/parsing_library/src/main/java/chesire/eorzeaninfo/parsing_library/models/DetailedCharacterModel.java
+++ b/EorzeanInfo/parsing_library/src/main/java/chesire/eorzeaninfo/parsing_library/models/DetailedCharacterModel.java
@@ -3,8 +3,6 @@ package chesire.eorzeaninfo.parsing_library.models;
 import android.os.Parcel;
 import android.os.Parcelable;
 
-import java.util.List;
-
 public class DetailedCharacterModel extends BasicCharacterModel implements Parcelable {
     private int lodestone_id;
     private CharacterDataModel data;
@@ -53,12 +51,13 @@ public class DetailedCharacterModel extends BasicCharacterModel implements Parce
         }
     }
 
-    public List<MinMountModel> getMounts() {
-        return data.getMounts();
-    }
-
-    public List<MinMountModel> getMinions() {
-        return data.getMinions();
+    /**
+     * Get the data object for this character, which contains more information about it
+     *
+     * @return Data object with more detailed character information
+     */
+    public CharacterDataModel getData() {
+        return data;
     }
 
     @Override

--- a/EorzeanInfo/parsing_library/src/main/java/chesire/eorzeaninfo/parsing_library/serializers/CharacterDataModelDeserializer.java
+++ b/EorzeanInfo/parsing_library/src/main/java/chesire/eorzeaninfo/parsing_library/serializers/CharacterDataModelDeserializer.java
@@ -31,18 +31,20 @@ public class CharacterDataModelDeserializer implements JsonDeserializer<Characte
             classes.add(currentClass.getValue());
         }
 
+        /*
+        * Get all mounts & minions as a list of IDs,
+        * then we can just compare the IDS against the full list
+        */
         Set<Map.Entry<String, JsonElement>> mountsList = (json.getAsJsonObject().get("mounts")).getAsJsonObject().entrySet();
         JsonArray mounts = new JsonArray();
         for (Map.Entry<String, JsonElement> currentMount : mountsList) {
-            currentMount.getValue().getAsJsonObject().addProperty("type", "mount");
-            mounts.add(currentMount.getValue());
+            mounts.add(currentMount.getValue().getAsJsonObject().get("id"));
         }
 
         Set<Map.Entry<String, JsonElement>> minionsList = (json.getAsJsonObject().get("minions")).getAsJsonObject().entrySet();
         JsonArray minions = new JsonArray();
         for (Map.Entry<String, JsonElement> currentMinion : minionsList) {
-            currentMinion.getValue().getAsJsonObject().addProperty("type", "minion");
-            minions.add(currentMinion.getValue());
+            minions.add(currentMinion.getValue().getAsJsonObject().get("id"));
         }
 
         json.getAsJsonObject().add("classjobs", classes);


### PR DESCRIPTION
Currently the character data uses a list of MinMountModels, which for minions means having possibly 100+ more objects, change this so we just store the IDs and when going to the mount/minion fragment, just create lists containing what we have and are missing.